### PR TITLE
Fixed an issue creating newlines when line length is 69, Java 11 not …

### DIFF
--- a/utils/java.py
+++ b/utils/java.py
@@ -60,11 +60,11 @@ def create_manifest(path, properties, options):
 	# build up the list of lines
 	lines = []
 	for key in sorted(fullmap.keys()): # select a deterministic order
-		line = ("%s: %s"+os.linesep) % (key, fullmap[key])
+		line = ("%s: %s").strip() % (key, fullmap[key])
 		while len(line) > 70: # need to split long lines. Thanks Java. Thava.
 			lines.append(line[:70]+os.linesep)
 			line = " %s" % line[70:]
-		lines.append(line)
+		lines.append(line+os.linesep)
 
 	# nb: manifests are UTF-8 so if any of the lines are unicode strings 
 	# we probably should explicitly encode them to UTF-8 byte strings here


### PR DESCRIPTION
Fixed an issue creating newlines when line length is 69, Java 11 not allowing empty lines in manifest.
A sample will explain the issue easily,

```
Windows
>>> key = 'Implementation-Title'                                        
>>> val = 'Apama ADBC adapter - Java data source framework'
>>> import os
>>> l = ("%s: %s"+os.linesep) % (key, val)
>>> l
'Implementation-Title: Apama ADBC adapter - Java data source framework\r\n'
>>> l[70:]
'\n'
>>> l[:70]
'Implementation-Title: Apama ADBC adapter - Java data source framework\r'
>>> len(l)
71

Linux
>>> key = 'Implementation-Title'
>>> val = 'Apama ADBC adapter - Java data source framework'
>>> import os
>>> l = ("%s: %s"+os.linesep) % (key, val)
>>> l
'Implementation-Title: Apama ADBC adapter - Java data source framework\n'
>>> l[70:]
''
>>> l[:70]
'Implementation-Title: Apama ADBC adapter - Java data source framework\n'
>>> len(l)
70
```
