### PR TITLE
Eval string conditions in readPropertiesFromFile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 3.1 - current DEV release
 =========================
 
+.. py:currentmodule:: xpybuild
+
 Fixes
 -----
 
@@ -14,6 +16,9 @@ Enhancements
 - Added a new `pathsets.FindPaths` option ``FindPaths.globalExcludesFunction`` which can be used to globally exclude 
   certain file patterns throughout the build. By default this excludes files matching ``.nfs*`` (i.e. temporary NFS 
   files).
+- Added more powerful "conditions" to `propertysupport.definePropertiesFromFile`, allowing for complex Python 
+  expressions that check multiple conditions and properties to be used for dynamically selecting which lines are read 
+  from ``.properties`` files. 
 
 
 3.0

--- a/release-xpy.xpybuild.py
+++ b/release-xpy.xpybuild.py
@@ -35,7 +35,7 @@ requireXpybuildVersion('3.0')
 try:
 	import sphinx
 except ImportError:
-	raise Exception('Cannot build the xpybuild release as sphinx documentation library is not installed into this Python installation: %s (see .travis.yml for details of how to install)'%sys.executable)
+	raise Exception('Cannot build the xpybuild release as sphinx documentation library is not installed into this Python installation: %s (see .github/workflows for details of how to install)'%sys.executable)
 
 defineOutputDirProperty('OUTPUT_DIR', '_build_output')
 with open('xpybuild/XPYBUILD_VERSION') as f: defineStringProperty('VERSION', f.read().strip())

--- a/tests/_pysys_templates/xpybuild/Input/test.xpybuild.py
+++ b/tests/_pysys_templates/xpybuild/Input/test.xpybuild.py
@@ -1,0 +1,15 @@
+from xpybuild.propertysupport import *
+from xpybuild.buildcommon import *
+from xpybuild.pathsets import *
+
+from xpybuild.targets.writefile import *
+from xpybuild.targets.copy import *
+
+defineOutputDirProperty('OUTPUT_DIR', None)
+
+class CustomTarget(WriteFile):
+	def run(self, context):
+		self.log.critical('Test message from build file at CRIT level')
+		return super(CustomTarget, self).run(context)
+
+CustomTarget('${OUTPUT_DIR}/output.txt', 'Test message')

--- a/tests/_pysys_templates/xpybuild/pysystest.py
+++ b/tests/_pysys_templates/xpybuild/pysystest.py
@@ -9,4 +9,4 @@ class PySysTest(XpybuildBaseTest):
 		self.xpybuild(stdouterr='mytest', args=[])
 
 	def validate(self):
-		self.assertGrep('mytest.out', expr=r"XXX")
+		self.assertGrep('mytest.out', expr=r"XXX") # if no extra verifications are needed, instead use: self.addOutcome(PASSED)

--- a/tests/_pysys_templates/xpybuild/pysystest.py
+++ b/tests/_pysys_templates/xpybuild/pysystest.py
@@ -1,0 +1,12 @@
+@@DEFAULT_DESCRIPTOR@@
+
+import pysys
+from pysys.constants import *
+from xpybuild.xpybuild_basetest import XpybuildBaseTest
+
+class PySysTest(XpybuildBaseTest):
+	def execute(self):
+		self.xpybuild(stdouterr='mytest', args=[])
+
+	def validate(self):
+		self.assertGrep('mytest.out', expr=r"XXX")

--- a/tests/_pysys_templates/xpybuild/test.xpybuild.py
+++ b/tests/_pysys_templates/xpybuild/test.xpybuild.py
@@ -7,6 +7,8 @@ from xpybuild.targets.copy import *
 
 defineOutputDirProperty('OUTPUT_DIR', None)
 
+WriteFile('${OUTPUT_DIR}/output.txt', '\n'.join(['Hello']))
+
 class CustomTarget(WriteFile):
 	def run(self, context):
 		self.log.critical('Test message from build file at CRIT level')

--- a/tests/correctness/framework/PropertyConditions/Reference/props.txt
+++ b/tests/correctness/framework/PropertyConditions/Reference/props.txt
@@ -1,0 +1,4 @@
+got c2
+got c2,c3
+got !c4
+got complex expression

--- a/tests/correctness/framework/PropertyConditions/pysystest.py
+++ b/tests/correctness/framework/PropertyConditions/pysystest.py
@@ -1,0 +1,25 @@
+__pysys_title__   = r""" Properties - conditions in .properties files""" 
+#                        ================================================================================
+
+__pysys_purpose__ = r""" The purpose of this test is to check conditions such as <windows>, <windows, debug> 
+	and complex eval strings nested within <...> blocks work when reading .properties files. 
+	""" 
+	
+__pysys_authors__ = "bsp"
+__pysys_created__ = "2021-11-18"
+
+#__pysys_traceability_ids__ = "Bug-1234, UserStory-456" 
+#__pysys_groups__           = "myGroup, disableCoverage, performance; inherit=true"
+#__pysys_skipped_reason__   = "Skipped until Bug-1234 is fixed"
+#__pysys_modes__            = """ lambda helper: helper.combineModeDimensions(helper.inheritedModes, helper.makeAllPrimary({'MyMode':{'MyParam':123}})) """
+
+import pysys
+from pysys.constants import *
+from xpybuild.xpybuild_basetest import XpybuildBaseTest
+
+class PySysTest(XpybuildBaseTest):
+	def execute(self):
+		self.xpybuild(stdouterr='mytest', args=[])
+
+	def validate(self):
+		self.assertDiff('build-output/props.txt', 'props.txt')

--- a/tests/correctness/framework/PropertyConditions/test.properties
+++ b/tests/correctness/framework/PropertyConditions/test.properties
@@ -1,0 +1,6 @@
+MY_PROPERTY_A<c1>=got c1
+MY_PROPERTY_A<c2>=got c2
+MY_PROPERTY_B<c2, c3 >=got c2,c3
+MY_PROPERTY_C<'c4' not in conditions>=got !c4
+MY_PROPERTY_C<'c4' in conditions>=got c4
+MY_PROPERTY_D< context.getPropertyValue('OUTPUT_DIR') and import_module('math') and (IS_WINDOWS or not IS_WINDOWS)>=got complex expression

--- a/tests/correctness/framework/PropertyConditions/test.xpybuild.py
+++ b/tests/correctness/framework/PropertyConditions/test.xpybuild.py
@@ -1,0 +1,18 @@
+from xpybuild.propertysupport import *
+from xpybuild.buildcommon import *
+from xpybuild.pathsets import *
+
+from xpybuild.targets.writefile import *
+from xpybuild.targets.copy import *
+
+defineOutputDirProperty('OUTPUT_DIR', None)
+
+definePropertiesFromFile('test.properties', conditions=['c2', 'c3'])
+
+WriteFile('${OUTPUT_DIR}/props.txt', '\n'.join([
+	'${MY_PROPERTY_A}',
+	'${MY_PROPERTY_B}',
+	'${MY_PROPERTY_C}',
+	'${MY_PROPERTY_D}',
+]))
+

--- a/tests/pysysproject.xml
+++ b/tests/pysysproject.xml
@@ -54,6 +54,8 @@
 		<maker-template name="xpybuild" description="a test that runs xpybuild" 
 			copy="./_pysys_templates/xpybuild/*" />
 
+			<!-- Special option that auto-detects based on presence of an Input/ dir -->
+			<input-dir>!Input_dir_if_present_else_testDir!</input-dir>
 	</pysysdirconfig>
 	
 	<!-- Add project-specific text to be appended to the "pysys run -h". -->

--- a/tests/pysysproject.xml
+++ b/tests/pysysproject.xml
@@ -47,6 +47,14 @@
 		<default-file-encoding pattern="*.json" encoding="utf-8"/>
 		<default-file-encoding pattern="*.yaml" encoding="utf-8"/>
 	</default-file-encodings>
+
+
+	<pysysdirconfig>
+		
+		<maker-template name="xpybuild" description="a test that runs xpybuild" 
+			copy="./_pysys_templates/xpybuild/*" />
+
+	</pysysdirconfig>
 	
 	<!-- Add project-specific text to be appended to the "pysys run -h". -->
 	<project-help>


### PR DESCRIPTION
The lack of "not" was causing some problems. Rather than just adding that, added a general-purpose capability we can use for powerful conditions. 

Also added maketest templates for easier test writing. 